### PR TITLE
Basic support for multiple training runs.

### DIFF
--- a/src/db/models.go
+++ b/src/db/models.go
@@ -11,6 +11,7 @@ type User struct {
 
 	Username string
 	Password string
+	AssignedTrainingRunID uint
 }
 
 type TrainingRun struct {
@@ -23,6 +24,8 @@ type TrainingRun struct {
 	Description     string
 	TrainParameters string
 	Active          bool
+	LastNetwork     uint
+	LastGame        uint
 }
 
 type Network struct {
@@ -30,6 +33,8 @@ type Network struct {
 	CreatedAt time.Time
 
 	TrainingRunID uint
+	// Scoped to training run
+	NetworkNumber uint
 
 	Sha  string
 	Path string
@@ -96,6 +101,9 @@ type TrainingGame struct {
 	TrainingRunID uint
 	Network       Network
 	NetworkID     uint `gorm:"index"`
+
+	// Scoped to training run.
+	GameNumber uint
 
 	Version   uint
 	Path      string


### PR DESCRIPTION
The existing code wasn't really too far away, which helps a lot, but there are some key things I've added here.
1) Networks have a run sequence number property - this is intended (but not fully integrated) to provide a nice display number for users to see and talk about rather than interleaved primary key numbers that you get for concurrent runs.
2) Games have a run sequence number property - this is used for the file names on disk which are under their per run subdirectory.  This is needed for existing training server to be able to continue assuming that game numbers are sequential in order to decide when to stop waiting for games to arrive.

Other tables could have display numbers as well, but I didn't feel they were worth the code investment at this point.

Upgrading to this code will need to be done with care, as db upgrade will default the new sequence numbers to start from 0 - which for the game sequence numbers would be bad for the run in progress.