### PR TITLE
Another round of changes from live.

### DIFF
--- a/cmd/populate_elo/main.go
+++ b/cmd/populate_elo/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"db"
+	"io/ioutil"
+	"log"
+	"strconv"
+	"strings"
+	//	"github.com/marcsauter/single"
+)
+
+func populateElo() {
+	//  Get all networks.
+	var networks []db.Network
+	err := db.GetDB().Order("id").Find(&networks).Error
+	if err != nil {
+		log.Println("get network failed.")
+		return
+	}
+	networkNums := make(map[uint]uint)
+	for i, network := range networks {
+		networkNums[network.NetworkNumber] = uint(i)
+	}
+	data, err := ioutil.ReadFile("match_pgns/output.csv")
+	if err != nil {
+		log.Println("Failed to read data.")
+		return
+	}
+	fileContent := string(data)
+	lines := strings.Split(fileContent, "\n")
+	for i, line := range lines {
+		if i == 0 {
+			continue
+		}
+		parts := strings.Split(line, ",")
+		if len(parts) != 3 {
+			continue
+		}
+		name := strings.Trim(parts[1], "\"")
+		if !strings.HasPrefix(name, "lc0.net.") {
+			continue
+		}
+		name = strings.TrimPrefix(name, "lc0.net.")
+		netNum, err := strconv.ParseUint(name, 10, 32)
+		elo, err := strconv.ParseFloat(parts[2], 64)
+		idx := networkNums[uint(netNum)]
+		network := networks[idx]
+		if network.Anchor {
+			continue
+		}
+		err = db.GetDB().Model(&network).Update("elo", elo).Error
+		if err != nil {
+			log.Println("Failed to update elo")
+			return
+		}
+		err = db.GetDB().Model(&network).Update("elo_set", true).Error
+		if err != nil {
+			log.Println("Failed to update elo set status.")
+			return
+		}
+	}
+}
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	//	s := single.New("populate_elo")
+	//	if err := s.CheckLock(); err != nil && err == single.ErrAlreadyRunning {
+	//		log.Fatal("another instance of the app is already running, exiting")
+	//	} else if err != nil {
+	// Another error occurred, might be worth handling it as well
+	//		log.Fatalf("failed to acquire exclusive app lock: %v", err)
+	//	}
+	//	defer s.TryUnlock()
+
+	db.Init()
+	defer db.Close()
+
+	populateElo()
+}

--- a/cmd/prepare_match_pgns/main.go
+++ b/cmd/prepare_match_pgns/main.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"db"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	//	"github.com/marcsauter/single"
+)
+
+func prepareMatches() {
+	//  Get all matches and networks.
+	var matches []db.Match
+	err := db.GetDB().Order("id").Find(&matches).Error
+	if err != nil {
+		log.Println("get matches failed.")
+		return
+	}
+
+	var networks []db.Network
+	err = db.GetDB().Order("id").Find(&networks).Error
+	if err != nil {
+		log.Println("get network failed.")
+		return
+	}
+	networkNums := make(map[uint]uint)
+	anchors := make(map[uint][]uint)
+	anchorMatches := make(map[uint][][]string)
+	anchorsNew := make(map[uint][]bool)
+	anchorElos := make(map[uint][]float64)
+	for _, network := range networks {
+		networkNums[network.ID] = network.NetworkNumber
+		if network.Anchor {
+			if anchors[network.TrainingRunID] == nil {
+				anchors[network.TrainingRunID] = make([]uint, 0)
+				anchorMatches[network.TrainingRunID] = make([][]string, 0)
+				anchorsNew[network.TrainingRunID] = make([]bool, 0)
+				anchorElos[network.TrainingRunID] = make([]float64, 0)
+			}
+			anchors[network.TrainingRunID] = append(anchors[network.TrainingRunID], network.NetworkNumber)
+			anchorMatches[network.TrainingRunID] = append(anchorMatches[network.TrainingRunID], make([]string, 0))
+			anchorsNew[network.TrainingRunID] = append(anchorsNew[network.TrainingRunID], false)
+			anchorElos[network.TrainingRunID] = append(anchorElos[network.TrainingRunID], network.Elo)
+		}
+	}
+	os.MkdirAll("match_pgns", os.ModePerm)
+	log.Println("Starting matches")
+	for i := range matches {
+		match := matches[i]
+		if !match.Done || match.SpecialParams {
+			continue
+		}
+		filename := "match_pgns/" + strconv.Itoa(int(match.TrainingRunID)) + "/" + strconv.Itoa(int(match.ID)) + ".pgn"
+		searchTarget := networkNums[match.CurrentBestID]
+		possibleAnchors := anchors[match.TrainingRunID]
+		anchorIdx := sort.Search(len(possibleAnchors), func(j int) bool { return possibleAnchors[j] > searchTarget }) - 1
+		if anchorIdx < 0 {
+			log.Println("Failed to find anchor for match: " + strconv.Itoa(int(match.ID)))
+			log.Println("It will be ignored.")
+			log.Println("Candidates:")
+			for _, an := range possibleAnchors {
+				log.Println(strconv.Itoa(int(an)))
+			}
+			log.Println("Searched for: " + strconv.Itoa(int(searchTarget)))
+			continue
+		}
+		anchorMatches[match.TrainingRunID][anchorIdx] = append(anchorMatches[match.TrainingRunID][anchorIdx], filename)
+		if _, err := os.Stat(filename); !os.IsNotExist(err) {
+			continue
+		}
+		anchorsNew[match.TrainingRunID][anchorIdx] = true
+		log.Println("Creating: " + filename)
+		os.MkdirAll(filepath.Dir(filename), os.ModePerm)
+		var games []db.MatchGame
+		err := db.GetDB().Order("id").Where("match_id = ?", match.ID).Find(&games).Error
+		if err != nil {
+			return
+		}
+		var str strings.Builder
+		for _, game := range games {
+			if !game.Done {
+				continue
+			}
+			first := match.CandidateID
+			second := match.CurrentBestID
+			rawResult := game.Result
+			if game.Flip {
+				second, first = first, second
+				rawResult = -rawResult
+			}
+			second = networkNums[second]
+			first = networkNums[first]
+			result := "1/2-1/2"
+			if rawResult == 1 {
+				result = "1-0"
+			} else if rawResult == -1 {
+				result = "0-1"
+			}
+			str.WriteString("[Event \"lc0MG\"]\n")
+			str.WriteString("[Site \"internet\"]\n")
+			str.WriteString("[Date \"????.??.??\"]\n")
+			str.WriteString("[Round \"-\"]\n")
+			str.WriteString("[White \"lc0.net." + strconv.Itoa(int(first)) + "\"]\n")
+			str.WriteString("[Black \"lc0.net." + strconv.Itoa(int(second)) + "\"]\n")
+			str.WriteString("[Result \"" + result + "\"]\n")
+			str.WriteString(game.Pgn + "\n\n")
+		}
+		err = ioutil.WriteFile(filename, []byte(str.String()), 0644)
+		if err != nil {
+			return
+		}
+	}
+	var ordoScript strings.Builder
+	ordoScript.WriteString("#!/bin/bash\n\n")
+	ordoScript.WriteString("rm match_pgns/output.csv\n")
+	for run, _ := range anchors {
+		for i, enabled := range anchorsNew[run] {
+			if !enabled {
+				continue
+			}
+			var matchList strings.Builder
+			listname := "match_pgns/matchlist_" + strconv.Itoa(int(run)) + "_" + strconv.Itoa(int(i)) + ".list"
+			outputname := "match_pgns/output_" + strconv.Itoa(int(run)) + "_" + strconv.Itoa(int(i)) + ".outputcsv"
+			anchorName := "lc0.net." + strconv.Itoa(int(anchors[run][i]))
+			anchorElo := strconv.FormatFloat(anchorElos[run][i], 'f', -1, 64)
+			for _, name := range anchorMatches[run][i] {
+				matchList.WriteString(name + "\n")
+			}
+			err = ioutil.WriteFile(listname, []byte(matchList.String()), 0644)
+			if err != nil {
+				log.Println("Failed to write matchList: " + listname)
+				return
+			}
+			ordoScript.WriteString("~/ordo/ordo -G -Q -N 0 -D  -a " + anchorElo + " -A " + anchorName + " -W -n4  -V -U \"0,1\"  -c " + outputname + " -P " + listname + "\n")
+			ordoScript.WriteString("cat " + outputname + " >> match_pgns/output.csv\n")
+		}
+	}
+	err = ioutil.WriteFile("match_pgns/ordo.sh", []byte(ordoScript.String()), 0755)
+	if err != nil {
+		log.Println("Failed to write ordoScript.")
+		return
+	}
+}
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	//	s := single.New("prepapre_match_games")
+	//	if err := s.CheckLock(); err != nil && err == single.ErrAlreadyRunning {
+	//		log.Fatal("another instance of the app is already running, exiting")
+	//	} else if err != nil {
+	// Another error occurred, might be worth handling it as well
+	//		log.Fatalf("failed to acquire exclusive app lock: %v", err)
+	//	}
+	//	defer s.TryUnlock()
+
+	db.Init()
+	defer db.Close()
+
+	prepareMatches()
+}

--- a/src/db/models.go
+++ b/src/db/models.go
@@ -45,7 +45,9 @@ type Network struct {
 	// Cached here, as expensive to do COUNT(*) on Postgresql
 	GamesPlayed int
 
-	Elo float64
+	Elo    float64
+	Anchor bool
+	EloSet bool
 }
 
 type Match struct {
@@ -71,6 +73,8 @@ type Match struct {
 
 	// If true, this is not a promotion match
 	TestOnly bool
+	// If true, match is unusual so shouldn't be used for elo.
+	SpecialParams bool
 }
 
 type MatchGame struct {

--- a/templates/networks.tmpl
+++ b/templates/networks.tmpl
@@ -12,6 +12,7 @@
         <th>Blocks</th>
         <th>Filters</th>
         <th>Time</th>
+        <th>Ordo Elo</th>
       </tr>
     </thead>
     <tbody>
@@ -25,6 +26,7 @@
         <td>{{.blocks}}</td>
         <td>{{.filters}}</td>
         <td>{{.created_at}}</td>
+        <td>{{.real_elo}}</td>
       </tr>
       {{end}}
     </tbody>


### PR DESCRIPTION
Adds support for delegating elo calculations to ordo.  A net can have status 'EloSet' which means it won't be subject to runtime calculated elo.  A net can also have status 'Anchor' which means the set elo will be preserved.  The anchor must always be the first net from a restart within a run.
To help this new support actually be useful, every net ends up playing matches against 3 older nets (1 3 and 10 network numbers prior).  Keep time set to 16 hours to avoid this causing significant increase in network downloads.

Match games now correctly can target any 2 nets.  (While one of them is called 'CurrentBest', it can now be something else and still work.)

Removed microseconds from the timestamps on matches and networks page.
Changed color of 'test' matches now that there are so many more of them.
Delete temporary files created during the zipped-xor-delta uploadNetwork path.
Add a new flag to be able to filter progress graph to only the current series of nets from a run, based on the fact that the anchor is always first.

