### PR TITLE
Match limit on initial match page

### DIFF
--- a/main.go
+++ b/main.go
@@ -1388,14 +1388,13 @@ func viewMatches(c *gin.Context) {
 	var err error
 	run := c.Param("run")
 	run = strings.TrimPrefix(run, "/")
-	// 100 is a magic number used to limit initial page size
-	if run == "" || run == "100" {
+	if run == "" {
 		err = db.GetDB().Order("id desc").Find(&matches).Error
-		if run == "100" {
-			matches := matches[0:99]
-		}
 	} else {
 		err = db.GetDB().Order("id desc").Where("training_run_id = ?", run).Find(&matches).Error
+	}
+	if c.DefaultQuery("show_all", "1") == "0" {
+		matches := matches[0:99]
 	}
 	if err != nil {
 		log.Println(err)

--- a/main.go
+++ b/main.go
@@ -1388,8 +1388,12 @@ func viewMatches(c *gin.Context) {
 	var err error
 	run := c.Param("run")
 	run = strings.TrimPrefix(run, "/")
-	if run == "" {
+	// 100 is a magic number used to limit initial page size
+	if run == "" || run == "100" {
 		err = db.GetDB().Order("id desc").Find(&matches).Error
+		if run == "100" {
+			matches := matches[0:99]
+		}
 	} else {
 		err = db.GetDB().Order("id desc").Where("training_run_id = ?", run).Find(&matches).Error
 	}

--- a/templates/base.tmpl
+++ b/templates/base.tmpl
@@ -67,7 +67,7 @@
                 </a>
               </li>
               <li class="nav-item">
-                <a class="nav-link" href="/matches/100">
+                <a class="nav-link" href="/matches/?show_all=0">
                   <span data-feather="minimize-2"></span>
                   Matches
                 </a>

--- a/templates/base.tmpl
+++ b/templates/base.tmpl
@@ -67,7 +67,7 @@
                 </a>
               </li>
               <li class="nav-item">
-                <a class="nav-link" href="/matches">
+                <a class="nav-link" href="/matches/100">
                   <span data-feather="minimize-2"></span>
                   Matches
                 </a>

--- a/templates/matches.tmpl
+++ b/templates/matches.tmpl
@@ -33,7 +33,7 @@
       {{end}}
     </tbody>
   </table>
-  <a href="/matches/">show all matches (warning: large page)</a>
+  <a href="/matches/?show_all=1">show all matches (warning: large page)</a>
 </div>
 {{end}}
 

--- a/templates/matches.tmpl
+++ b/templates/matches.tmpl
@@ -33,6 +33,7 @@
       {{end}}
     </tbody>
   </table>
+  <a href="/matches/">show all matches (warning: large page)</a>
 </div>
 {{end}}
 


### PR DESCRIPTION
The matches page is becoming very large and takes a long time to load up. 
Have added a slice of 100 to limit the initial page size.
Note: I do not have the postgresDB running so this code change is pretty blind; please test before merging.